### PR TITLE
Uniform Ids

### DIFF
--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_1997_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_1997_I2D2_LFS.do
@@ -136,52 +136,52 @@ if (`append' == 1) {
 
 
 ** HOUSEHOLD IDENTIFICATION NUMBER
-	* make each variable string, if not already 
 	loc idhvars 	regn  prov  domain urb panel hcn	// store idh vars in local
-	
-	* make new values with desired length of each variable
+
+	* starting locals 
 	loc len = 4											// declare the length of each element in digits
 	loc idh_els ""										// start with empty local list
-	
+
+	* make each variable string, including leading zeros
 	foreach var of local idhvars {
 		tostring `var'	///
 			, generate(idh_`var') ///
 			force format(`"%0`len'.0f"')
-			
+
 		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
-		
+
 	}
-		
+
 	* concatenate to form idh: hosehold id
 	egen idh=concat( `idh_els' )						// concatenate vars we just made. code drops vars @ end
-	
+
 	label var idh "Household id"
-	
+
 
 
 
 ** INDIVIDUAL IDENTIFICATION NUMBER
 	bys idh: gen n_fam = _n								// generate family member number
-	
-	* repeat same process from above, but only with n_fam 
+
+	* repeat same process from above, but only with n_fam
 	loc idpvars 	n_fam 								// store relevant idp vars in local
-	
+
 	* make new values with desired length of each variable
 	loc len = 2											// declare the length of each element in digits
 	loc idp_els ""										// start with empty local list
-	
+
 	foreach var of local idpvars {
 		tostring `var'	///
 			, generate(idp_`var') ///
 			force format(`"%0`len'.0f"')
-			
+
 		loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
-		
+
 	}
-		
+
 	* concatenate to form idp: individual id
 	egen idp=concat( `idp_els' )						// concatenate vars we just made. code drops vars @ end
-		
+
 	sort idh idp
 	label var idp "Individual id"
 
@@ -189,7 +189,7 @@ if (`append' == 1) {
 	isid idh idp 										// household and individual id uniquely identify
 
 
-	
+
 
 ** HOUSEHOLD WEIGHTS
 	/* The weight variable will be divided by the number of rounds per year to ensure the

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_1997_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_1997_I2D2_LFS.do
@@ -136,17 +136,19 @@ if (`append' == 1) {
 
 
 ** HOUSEHOLD IDENTIFICATION NUMBER
-	loc idhvars 	regn  prov  domain urb panel hcn	// store idh vars in local
+	loc idhvars 	regn  prov  domain urb panel hcn 	// store idh vars in local
+	ds `idhvars',  	has(type numeric)			// filter out numeric variables in local
+	loc rlist 		= r(varlist)				// store numeric vars in local
 
-	* starting locals 
+	* starting locals
 	loc len = 4											// declare the length of each element in digits
 	loc idh_els ""										// start with empty local list
 
 	* make each variable string, including leading zeros
-	foreach var of local idhvars {
-		tostring `var'	///
-			, generate(idh_`var') ///
-			force format(`"%0`len'.0f"')
+	foreach var of local rlist {
+		tostring `var'	///								// make the numeric vars strings
+			, generate(idh_`var') ///					// gen a variable with this prefix
+			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
 
 		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
 
@@ -165,15 +167,17 @@ if (`append' == 1) {
 
 	* repeat same process from above, but only with n_fam
 	loc idpvars 	n_fam 								// store relevant idp vars in local
+	ds `idpvars',  	has(type numeric)			// filter out numeric variables in local
+	loc rlist 		= r(varlist)				// store numeric vars in local
 
 	* make new values with desired length of each variable
 	loc len = 2											// declare the length of each element in digits
 	loc idp_els ""										// start with empty local list
 
 	foreach var of local idpvars {
-		tostring `var'	///
-			, generate(idp_`var') ///
-			force format(`"%0`len'.0f"')
+		tostring `var'	///								// make numeric variables strings
+			, generate(idp_`var') ///					// generate a variable with this prefix
+			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
 
 		loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
 
@@ -187,6 +191,7 @@ if (`append' == 1) {
 
 ** ID CHECKS
 	isid idh idp 										// household and individual id uniquely identify
+
 
 
 

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_1997_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_1997_I2D2_LFS.do
@@ -136,22 +136,72 @@ if (`append' == 1) {
 
 
 ** HOUSEHOLD IDENTIFICATION NUMBER
-	egen idh=concat( regn  prov  domain urb panel hcn )
-	destring idh, float 
-	sort idh
+	* make each variable string, if not already 
+	loc idhvars regn  prov  domain urb panel hcn		// store idh vars in local
+	
+	ds `idhvars', has(type numeric)						// extract numeric vars
+	loc returnlist = r(varlist)
+	
+	foreach var of local returnlist {					// convert numeric vars to string
+		tostring `var', replace force
+	}							
+	
+	* make new values with desired length of each variable
+	* from: https://stackoverflow.com/questions/30545193/trailing-zeros-in-string-format-in-stata
+	loc len  = 4
+	foreach var of local idhvars {
+		gen xdif_`var' = 10 ^ (`len' - length(`var'))	// gen a legnth scalar for each var
+		gen real_`var' = real(`var') * xdif_`var'			// make a numeric version with scalar
+	}
+		
+	* concatenate, then destring
+	egen idh=concat( real_regn  real_prov  real_domain real_urb real_panel real_hcn )
+	*destring idh, generate(idh_float) float 
+	
+	*format idh %30.0f
 	label var idh "Household id"
+	
 
 
 
 ** INDIVIDUAL IDENTIFICATION NUMBER
 	bys idh: gen n_fam = _n		// generate family member number
+	
+	* repeat same process from above, but only with n_fam 
+	** make string 
+	loc idpvars 	n_fam 
+	
+	ds `idpvars', has(type numeric)						// extract numeric vars
+	loc returnlist = r(varlist)
+	
+	foreach var of local returnlist {					// convert numeric vars to string
+		tostring `var', replace force
+	}							
+	
+	* make new values with desired length of each variable
+	* from: https://stackoverflow.com/questions/30545193/trailing-zeros-in-string-format-in-stata
+	loc len  = 2
+	foreach var of local idpvars {
+		gen xdif_`var' = 10 ^ (`len' - length(`var'))	// gen a legnth scalar for each var
+		gen real_`var' = real(`var') * xdif_`var'			// make a numeric version with scalar
+	}
+	
+	egen idp=concat( idh real_n_fam)
 
-	egen idp=concat( idh n_fam)
+	sort idh idp
 	label var idp "Individual id"
 
 ** ID CHECKS
 	isid idh idp 	// household and individual id should uniquely identify
+	
+		/*The problem here is that this fails theid check because idp is actually 
+			the product of a failed algorithm, where number "01" becomes "10" and 10 
+			becomes "10" the only way to potentially get around this is to have 
+			1 more digit than you need or leave this as numeric. but what this 
+			actually means is that there may be situations in idh where we are 
+			"erasing" levels of unique nmumbers.*/
 
+	
 
 ** HOUSEHOLD WEIGHTS
 	/* The weight variable will be divided by the number of rounds per year to ensure the

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_1997_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_1997_I2D2_LFS.do
@@ -139,26 +139,28 @@ if (`append' == 1) {
 	* make each variable string, if not already 
 	loc idhvars regn  prov  domain urb panel hcn		// store idh vars in local
 	
-	ds `idhvars', has(type numeric)						// extract numeric vars
+	ds `idhvars', has(type string)						// extract numeric vars
 	loc returnlist = r(varlist)
 	
-	foreach var of local returnlist {					// convert numeric vars to string
+	/*)foreach var of local returnlist {				// convert numeric vars to string
 		tostring `var', replace force
 	}							
-	
+	*/
 	* make new values with desired length of each variable
 	* from: https://stackoverflow.com/questions/30545193/trailing-zeros-in-string-format-in-stata
 	loc len  = 4
+	loc idh_els ""		// start with empty local list
 	foreach var of local idhvars {
-		gen xdif_`var' = 10 ^ (`len' - length(`var'))	// gen a legnth scalar for each var
-		gen real_`var' = real(`var') * xdif_`var'			// make a numeric version with scalar
+		*gen str`len' idh_`var'  = string(`var', `"%0`len'.0f"')
+		tostring `var', generate(idh_`var') force format(`"%0`len'.0f"')
+		loc idh_els `idh_els' idh_`var'					// add each variable to the local list
+		
 	}
 		
-	* concatenate, then destring
-	egen idh=concat( real_regn  real_prov  real_domain real_urb real_panel real_hcn )
-	*destring idh, generate(idh_float) float 
+	* concatenate
+	egen idh=concat( `idh_els' )						// concatenate all variables we just made
 	
-	*format idh %30.0f
+	format idh %30.0f
 	label var idh "Household id"
 	
 
@@ -175,7 +177,7 @@ if (`append' == 1) {
 	loc returnlist = r(varlist)
 	
 	foreach var of local returnlist {					// convert numeric vars to string
-		tostring `var', replace force
+		tostring `var', replace force 
 	}							
 	
 	* make new values with desired length of each variable

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_1998_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_1998_I2D2_LFS.do
@@ -137,15 +137,18 @@ if (`append' == 1) {
 ** HOUSEHOLD IDENTIFICATION NUMBER
 	loc idhvars 	regn  prov  domain urb panel hcn 	// store idh vars in local
 
+	ds `idhvars',  	has(type numeric)			// filter out numeric variables in local
+	loc rlist 		= r(varlist)				// store numeric vars in local
+
 	* starting locals
 	loc len = 4											// declare the length of each element in digits
 	loc idh_els ""										// start with empty local list
 
 	* make each variable string, including leading zeros
-	foreach var of local idhvars {
-		tostring `var'	///
-			, generate(idh_`var') ///
-			force format(`"%0`len'.0f"')
+	foreach var of local rlist {
+		tostring `var'	///								// make the numeric vars strings
+			, generate(idh_`var') ///					// gen a variable with this prefix
+			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
 
 		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
 
@@ -164,15 +167,17 @@ if (`append' == 1) {
 
 	* repeat same process from above, but only with n_fam
 	loc idpvars 	n_fam 								// store relevant idp vars in local
+	ds `idpvars',  	has(type numeric)			// filter out numeric variables in local
+	loc rlist 		= r(varlist)				// store numeric vars in local
 
 	* make new values with desired length of each variable
 	loc len = 2											// declare the length of each element in digits
 	loc idp_els ""										// start with empty local list
 
 	foreach var of local idpvars {
-		tostring `var'	///
-			, generate(idp_`var') ///
-			force format(`"%0`len'.0f"')
+		tostring `var'	///								// make numeric variables strings
+			, generate(idp_`var') ///					// generate a variable with this prefix
+			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
 
 		loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
 
@@ -186,7 +191,6 @@ if (`append' == 1) {
 
 ** ID CHECKS
 	isid idh idp 										// household and individual id uniquely identify
-
 
 
 ** HOUSEHOLD WEIGHTS

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_1998_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_1998_I2D2_LFS.do
@@ -133,20 +133,59 @@ if (`append' == 1) {
 	label var month "Month of the interview"
 
 
+
 ** HOUSEHOLD IDENTIFICATION NUMBER
-	egen idh=concat( regn  prov  domain urb panel hcn )
-	sort idh
+	loc idhvars 	regn  prov  domain urb panel hcn 	// store idh vars in local
+
+	* starting locals
+	loc len = 4											// declare the length of each element in digits
+	loc idh_els ""										// start with empty local list
+
+	* make each variable string, including leading zeros
+	foreach var of local idhvars {
+		tostring `var'	///
+			, generate(idh_`var') ///
+			force format(`"%0`len'.0f"')
+
+		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
+
+	}
+
+	* concatenate to form idh: hosehold id
+	egen idh=concat( `idh_els' )						// concatenate vars we just made. code drops vars @ end
+
 	label var idh "Household id"
 
 
-** INDIVIDUAL IDENTIFICATION NUMBER
-	bys idh: gen n_fam = _n		// generate family member number
 
-	egen idp=concat( idh n_fam)
+
+** INDIVIDUAL IDENTIFICATION NUMBER
+	bys idh: gen n_fam = _n								// generate family member number
+
+	* repeat same process from above, but only with n_fam
+	loc idpvars 	n_fam 								// store relevant idp vars in local
+
+	* make new values with desired length of each variable
+	loc len = 2											// declare the length of each element in digits
+	loc idp_els ""										// start with empty local list
+
+	foreach var of local idpvars {
+		tostring `var'	///
+			, generate(idp_`var') ///
+			force format(`"%0`len'.0f"')
+
+		loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
+
+	}
+
+	* concatenate to form idp: individual id
+	egen idp=concat( `idp_els' )						// concatenate vars we just made. code drops vars @ end
+
+	sort idh idp
 	label var idp "Individual id"
 
 ** ID CHECKS
-	isid idh idp 	// household and individual id should uniquely identify
+	isid idh idp 										// household and individual id uniquely identify
 
 
 

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_1999_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_1999_I2D2_LFS.do
@@ -134,19 +134,59 @@ if (`cb_pause' == 1) {
 
 
 ** HOUSEHOLD IDENTIFICATION NUMBER
-	egen idh=concat( regn  prov  domain urb panel hcn )
-	sort idh
+	loc idhvars 	regn  prov  domain urb panel hcn	// store idh vars in local
+
+	* starting locals
+	loc len = 4											// declare the length of each element in digits
+	loc idh_els ""										// start with empty local list
+
+	* make each variable string, including leading zeros
+	foreach var of local idhvars {
+		tostring `var'	///
+			, generate(idh_`var') ///
+			force format(`"%0`len'.0f"')
+
+		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
+
+	}
+
+	* concatenate to form idh: hosehold id
+	egen idh=concat( `idh_els' )						// concatenate vars we just made. code drops vars @ end
+
 	label var idh "Household id"
 
 
-** INDIVIDUAL IDENTIFICATION NUMBER
-	bys idh: gen n_fam = _n		// generate family member number
 
-	egen idp=concat( idh n_fam)
+
+** INDIVIDUAL IDENTIFICATION NUMBER
+	bys idh: gen n_fam = _n								// generate family member number
+
+	* repeat same process from above, but only with n_fam
+	loc idpvars 	n_fam 								// store relevant idp vars in local
+
+	* make new values with desired length of each variable
+	loc len = 2											// declare the length of each element in digits
+	loc idp_els ""										// start with empty local list
+
+	foreach var of local idpvars {
+		tostring `var'	///
+			, generate(idp_`var') ///
+			force format(`"%0`len'.0f"')
+
+		loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
+
+	}
+
+	* concatenate to form idp: individual id
+	egen idp=concat( `idp_els' )						// concatenate vars we just made. code drops vars @ end
+
+	sort idh idp
 	label var idp "Individual id"
 
 ** ID CHECKS
-	isid idh idp 	// household and individual id should uniquely identify
+	isid idh idp 										// household and individual id uniquely identify
+
+
 
 
 

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_1999_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_1999_I2D2_LFS.do
@@ -136,15 +136,18 @@ if (`cb_pause' == 1) {
 ** HOUSEHOLD IDENTIFICATION NUMBER
 	loc idhvars 	regn  prov  domain urb panel hcn	// store idh vars in local
 
+	ds `idhvars',  	has(type numeric)			// filter out numeric variables in local
+	loc rlist 		= r(varlist)				// store numeric vars in local
+
 	* starting locals
 	loc len = 4											// declare the length of each element in digits
 	loc idh_els ""										// start with empty local list
 
 	* make each variable string, including leading zeros
-	foreach var of local idhvars {
-		tostring `var'	///
-			, generate(idh_`var') ///
-			force format(`"%0`len'.0f"')
+	foreach var of local rlist {
+		tostring `var'	///								// make the numeric vars strings
+			, generate(idh_`var') ///					// gen a variable with this prefix
+			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
 
 		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
 
@@ -163,15 +166,17 @@ if (`cb_pause' == 1) {
 
 	* repeat same process from above, but only with n_fam
 	loc idpvars 	n_fam 								// store relevant idp vars in local
+	ds `idpvars',  	has(type numeric)			// filter out numeric variables in local
+	loc rlist 		= r(varlist)				// store numeric vars in local
 
 	* make new values with desired length of each variable
 	loc len = 2											// declare the length of each element in digits
 	loc idp_els ""										// start with empty local list
 
 	foreach var of local idpvars {
-		tostring `var'	///
-			, generate(idp_`var') ///
-			force format(`"%0`len'.0f"')
+		tostring `var'	///								// make numeric variables strings
+			, generate(idp_`var') ///					// generate a variable with this prefix
+			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
 
 		loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
 

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_2000_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_2000_I2D2_LFS.do
@@ -136,15 +136,18 @@ if (`cb_pause' == 1) {
 ** HOUSEHOLD IDENTIFICATION NUMBER
 	loc idhvars 	regn  prov  domain urb panel hcn	// store idh vars in local
 
+	ds `idhvars',  	has(type numeric)			// filter out numeric variables in local
+	loc rlist 		= r(varlist)				// store numeric vars in local
+
 	* starting locals
 	loc len = 4											// declare the length of each element in digits
 	loc idh_els ""										// start with empty local list
 
 	* make each variable string, including leading zeros
-	foreach var of local idhvars {
-		tostring `var'	///
-			, generate(idh_`var') ///
-			force format(`"%0`len'.0f"')
+	foreach var of local rlist {
+		tostring `var'	///								// make the numeric vars strings
+			, generate(idh_`var') ///					// gen a variable with this prefix
+			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
 
 		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
 
@@ -163,15 +166,17 @@ if (`cb_pause' == 1) {
 
 	* repeat same process from above, but only with n_fam
 	loc idpvars 	n_fam 								// store relevant idp vars in local
+	ds `idpvars',  	has(type numeric)			// filter out numeric variables in local
+	loc rlist 		= r(varlist)				// store numeric vars in local
 
 	* make new values with desired length of each variable
 	loc len = 2											// declare the length of each element in digits
 	loc idp_els ""										// start with empty local list
 
 	foreach var of local idpvars {
-		tostring `var'	///
-			, generate(idp_`var') ///
-			force format(`"%0`len'.0f"')
+		tostring `var'	///								// make numeric variables strings
+			, generate(idp_`var') ///					// generate a variable with this prefix
+			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
 
 		loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
 

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_2000_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_2000_I2D2_LFS.do
@@ -134,20 +134,59 @@ if (`cb_pause' == 1) {
 
 
 ** HOUSEHOLD IDENTIFICATION NUMBER
-	egen idh=concat( regn  prov  domain urb panel hcn )
-	sort idh
+	loc idhvars 	regn  prov  domain urb panel hcn	// store idh vars in local
+
+	* starting locals
+	loc len = 4											// declare the length of each element in digits
+	loc idh_els ""										// start with empty local list
+
+	* make each variable string, including leading zeros
+	foreach var of local idhvars {
+		tostring `var'	///
+			, generate(idh_`var') ///
+			force format(`"%0`len'.0f"')
+
+		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
+
+	}
+
+	* concatenate to form idh: hosehold id
+	egen idh=concat( `idh_els' )						// concatenate vars we just made. code drops vars @ end
+
 	label var idh "Household id"
 
 
 
-** INDIVIDUAL IDENTIFICATION NUMBER
-	bys idh: gen n_fam = _n		// generate family member number
 
-	egen idp=concat( idh n_fam)
+** INDIVIDUAL IDENTIFICATION NUMBER
+	bys idh: gen n_fam = _n								// generate family member number
+
+	* repeat same process from above, but only with n_fam
+	loc idpvars 	n_fam 								// store relevant idp vars in local
+
+	* make new values with desired length of each variable
+	loc len = 2											// declare the length of each element in digits
+	loc idp_els ""										// start with empty local list
+
+	foreach var of local idpvars {
+		tostring `var'	///
+			, generate(idp_`var') ///
+			force format(`"%0`len'.0f"')
+
+		loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
+
+	}
+
+	* concatenate to form idp: individual id
+	egen idp=concat( `idp_els' )						// concatenate vars we just made. code drops vars @ end
+
+	sort idh idp
 	label var idp "Individual id"
 
 ** ID CHECKS
-	isid idh idp 	// household and individual id should uniquely identify
+	isid idh idp 										// household and individual id uniquely identify
+
+
 
 
 

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_2001_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_2001_I2D2_LFS.do
@@ -134,19 +134,60 @@ if (`cb_pause' == 1) {
 
 
 ** HOUSEHOLD IDENTIFICATION NUMBER
-	egen idh=concat( regn  prov cprrcd urb hcn ) // panel domain not in survey
-	sort idh
+	loc idhvars 	regn  prov cprrcd urb hcn 	// store idh vars in local
+
+	* starting locals
+	loc len = 4											// declare the length of each element in digits
+	loc idh_els ""										// start with empty local list
+
+	* make each variable string, including leading zeros
+	foreach var of local idhvars {
+		tostring `var'	///
+			, generate(idh_`var') ///
+			force format(`"%0`len'.0f"')
+
+		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
+
+	}
+
+	* concatenate to form idh: hosehold id
+	egen idh=concat( `idh_els' )						// concatenate vars we just made. code drops vars @ end
+
 	label var idh "Household id"
 
 
-** INDIVIDUAL IDENTIFICATION NUMBER
-	bys idh: gen n_fam = _n		// generate family member number
 
-	egen idp=concat( idh n_fam)
+
+** INDIVIDUAL IDENTIFICATION NUMBER
+	bys idh: gen n_fam = _n								// generate family member number
+
+	* repeat same process from above, but only with n_fam
+	loc idpvars 	n_fam 								// store relevant idp vars in local
+
+	* make new values with desired length of each variable
+	loc len = 2											// declare the length of each element in digits
+	loc idp_els ""										// start with empty local list
+
+	foreach var of local idpvars {
+		tostring `var'	///
+			, generate(idp_`var') ///
+			force format(`"%0`len'.0f"')
+
+		loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
+
+	}
+
+	* concatenate to form idp: individual id
+	egen idp=concat( `idp_els' )						// concatenate vars we just made. code drops vars @ end
+
+	sort idh idp
 	label var idp "Individual id"
 
 ** ID CHECKS
-	isid idh idp 	// household and individual id should uniquely identify
+	isid idh idp 										// household and individual id uniquely identify
+
+
+
 
 
 

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_2001_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_2001_I2D2_LFS.do
@@ -135,16 +135,18 @@ if (`cb_pause' == 1) {
 
 ** HOUSEHOLD IDENTIFICATION NUMBER
 	loc idhvars 	regn  prov cprrcd urb hcn 	// store idh vars in local
+	ds `idhvars',  	has(type numeric)			// filter out numeric variables in local 
+	loc rlist 		= r(varlist)				// store numeric vars in local
 
 	* starting locals
 	loc len = 4											// declare the length of each element in digits
 	loc idh_els ""										// start with empty local list
 
 	* make each variable string, including leading zeros
-	foreach var of local idhvars {
-		tostring `var'	///
-			, generate(idh_`var') ///
-			force format(`"%0`len'.0f"')
+	foreach var of local rlist {
+		tostring `var'	///								// make the numeric vars strings
+			, generate(idh_`var') ///					// gen a variable with this prefix
+			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
 
 		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
 
@@ -163,15 +165,17 @@ if (`cb_pause' == 1) {
 
 	* repeat same process from above, but only with n_fam
 	loc idpvars 	n_fam 								// store relevant idp vars in local
+	ds `idpvars',  	has(type numeric)			// filter out numeric variables in local 
+	loc rlist 		= r(varlist)				// store numeric vars in local
 
 	* make new values with desired length of each variable
 	loc len = 2											// declare the length of each element in digits
 	loc idp_els ""										// start with empty local list
 
 	foreach var of local idpvars {
-		tostring `var'	///
-			, generate(idp_`var') ///
-			force format(`"%0`len'.0f"')
+		tostring `var'	///								// make numeric variables strings
+			, generate(idp_`var') ///					// generate a variable with this prefix
+			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local 
 
 		loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
 

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_2001_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_2001_I2D2_LFS.do
@@ -135,7 +135,7 @@ if (`cb_pause' == 1) {
 
 ** HOUSEHOLD IDENTIFICATION NUMBER
 	loc idhvars 	regn  prov cprrcd urb hcn 	// store idh vars in local
-	ds `idhvars',  	has(type numeric)			// filter out numeric variables in local 
+	ds `idhvars',  	has(type numeric)			// filter out numeric variables in local
 	loc rlist 		= r(varlist)				// store numeric vars in local
 
 	* starting locals
@@ -165,7 +165,7 @@ if (`cb_pause' == 1) {
 
 	* repeat same process from above, but only with n_fam
 	loc idpvars 	n_fam 								// store relevant idp vars in local
-	ds `idpvars',  	has(type numeric)			// filter out numeric variables in local 
+	ds `idpvars',  	has(type numeric)			// filter out numeric variables in local
 	loc rlist 		= r(varlist)				// store numeric vars in local
 
 	* make new values with desired length of each variable
@@ -175,7 +175,7 @@ if (`cb_pause' == 1) {
 	foreach var of local idpvars {
 		tostring `var'	///								// make numeric variables strings
 			, generate(idp_`var') ///					// generate a variable with this prefix
-			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local 
+			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
 
 		loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
 

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_2002_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_2002_I2D2_LFS.do
@@ -136,19 +136,58 @@ if (`cb_pause' == 1) {
 
 
 ** HOUSEHOLD IDENTIFICATION NUMBER
-	egen idh=concat( regn  prov stratum urb hcn ) // panel domain not in survey
-	sort idh
+	loc idhvars 	regn  prov stratum urb hcn 	// store idh vars in local
+
+	* starting locals
+	loc len = 4											// declare the length of each element in digits
+	loc idh_els ""										// start with empty local list
+
+	* make each variable string, including leading zeros
+	foreach var of local idhvars {
+		tostring `var'	///
+			, generate(idh_`var') ///
+			force format(`"%0`len'.0f"')
+
+		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
+
+	}
+
+	* concatenate to form idh: hosehold id
+	egen idh=concat( `idh_els' )						// concatenate vars we just made. code drops vars @ end
+
 	label var idh "Household id"
 
 
-** INDIVIDUAL IDENTIFICATION NUMBER
-	bys idh: gen n_fam = _n		// generate family member number
 
-	egen idp=concat( idh n_fam)
+
+** INDIVIDUAL IDENTIFICATION NUMBER
+	bys idh: gen n_fam = _n								// generate family member number
+
+	* repeat same process from above, but only with n_fam
+	loc idpvars 	n_fam 								// store relevant idp vars in local
+
+	* make new values with desired length of each variable
+	loc len = 2											// declare the length of each element in digits
+	loc idp_els ""										// start with empty local list
+
+	foreach var of local idpvars {
+		tostring `var'	///
+			, generate(idp_`var') ///
+			force format(`"%0`len'.0f"')
+
+		loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
+
+	}
+
+	* concatenate to form idp: individual id
+	egen idp=concat( `idp_els' )						// concatenate vars we just made. code drops vars @ end
+
+	sort idh idp
 	label var idp "Individual id"
 
 ** ID CHECKS
-	isid idh idp 	// household and individual id should uniquely identify
+	isid idh idp 										// household and individual id uniquely identify
+
 
 
 

--- a/GLD-Harmonization/TM/PHL/I2D2/PHL_2002_I2D2_LFS.do
+++ b/GLD-Harmonization/TM/PHL/I2D2/PHL_2002_I2D2_LFS.do
@@ -138,15 +138,18 @@ if (`cb_pause' == 1) {
 ** HOUSEHOLD IDENTIFICATION NUMBER
 	loc idhvars 	regn  prov stratum urb hcn 	// store idh vars in local
 
+	ds `idhvars',  	has(type numeric)			// filter out numeric variables in local
+	loc rlist 		= r(varlist)				// store numeric vars in local
+
 	* starting locals
 	loc len = 4											// declare the length of each element in digits
 	loc idh_els ""										// start with empty local list
 
 	* make each variable string, including leading zeros
-	foreach var of local idhvars {
-		tostring `var'	///
-			, generate(idh_`var') ///
-			force format(`"%0`len'.0f"')
+	foreach var of local rlist {
+		tostring `var'	///								// make the numeric vars strings
+			, generate(idh_`var') ///					// gen a variable with this prefix
+			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
 
 		loc idh_els 	`idh_els' idh_`var'				// add each variable to the local list
 
@@ -165,15 +168,17 @@ if (`cb_pause' == 1) {
 
 	* repeat same process from above, but only with n_fam
 	loc idpvars 	n_fam 								// store relevant idp vars in local
+	ds `idpvars',  	has(type numeric)			// filter out numeric variables in local
+	loc rlist 		= r(varlist)				// store numeric vars in local
 
 	* make new values with desired length of each variable
 	loc len = 2											// declare the length of each element in digits
 	loc idp_els ""										// start with empty local list
 
 	foreach var of local idpvars {
-		tostring `var'	///
-			, generate(idp_`var') ///
-			force format(`"%0`len'.0f"')
+		tostring `var'	///								// make numeric variables strings
+			, generate(idp_`var') ///					// generate a variable with this prefix
+			force format(`"%0`len'.0f"')				// ...and the specified number of digits in local
 
 		loc idp_els 	`idp_els' idp_`var'				// add each variable to the local list
 
@@ -187,7 +192,6 @@ if (`cb_pause' == 1) {
 
 ** ID CHECKS
 	isid idh idp 										// household and individual id uniquely identify
-
 
 
 


### PR DESCRIPTION
The goal is to write codes that generates two ids, `idh` the household id and `idp` the individual id that:

1. together, uniquely identify all observations, 
2. are never missing
3. and are the same length, at least within each survey year

The problem is that I can't figure out a way to do this. The general strategy it to combine a standard combination of variables to get the family id `idh`, then simply add a line number for `idp`. This is all good. And you can do the first two no problem.

The problem enters with number 3, because from what I know there's no easy way to standardize variable lengths that are numerics -- and these variable are numeric, or are string made of numbers. 

If you go the numeric route, and try to generate a concatenated variable of numeric sub-variables, first of all stata gives you a string variable which you have to `destring` to make numeric again. Then for some reason when you get to creating the `idp` variable you notice that stata thinks there are far fewer distinct numbers of `idh` than there really are. And I don't think this has to do with the `float` storage type, but maybe? So that won't do.

Then if you go the string route, the strategy here is to pad the actual number with a certain number of `0`s, so `14` becomes `00014` or whatever. Except this code as I have it essentially pads the `0`s on the end, making `1` into `1000` which obviously is a problem because `1000` is a potential number and then you lose distinct levels. Then again, `isid` won't work. 

Thoughts?